### PR TITLE
Fixes issues with Sendgrid

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,11 @@ Package also adds possibility to configure your Mandrill templates in the code a
 ## Compatibility
 Package is compatible with Laravel 5.2.
 
+### SendGrid
+New SendGrid API has some downsides when it comes to sending emails to multiple recipients. In order not to break anything, SendGrid mailer treats all recipients as of `to` type.
+
+For more information, please check https://github.com/sendgrid/sendgrid-php#please-read-this.
+
 ## Installation
 
 ### Version >= 2.0
@@ -194,7 +199,7 @@ interface MailerInterface
 - `addLocalVariable()`: adds variable for specified recipient (in Manrdill it is equivalent to merge var, in SendGrid it is equivalent to substitution); requires `Recipient` and `Variable` objects as arguments
 - `addAttachment()`: adds attachment to the message; requires `Attachment` object as argument
 - `send()`: sends message to previously defined recipients; email subject (`string`) and template identifier (`string`) can be passed (if subject and/or template id was not set before)
-- `queue()`: adds email to queue (**it uses Laravel queue mechanism**); queue name (`string`) can be passed as first param (by default it is set to 'mandrill'/'sendgrid'); email subject (`string`) and template identifier (`string`) can also be passed (if not set before)
+- `queue()`: adds email to queue (**it uses Laravel queue mechanism**); queue name (`string`) must be passed as first param; email subject (`string`) and template identifier (`string`) can also be passed (if not set before)
 - `getData()`: gets mailer whole configuration, i.e. recipients, variables, header, etc.; returns `array`
 - `setData()`: sets mailer configuration; requires `array`
 

--- a/spec/Mandrill/MailerSpec.php
+++ b/spec/Mandrill/MailerSpec.php
@@ -611,6 +611,6 @@ class MailerSpec extends ObjectBehavior
         $job = new Job($data);
         $queue->pushOn('mandrill', $job)->shouldBeCalled();
 
-        $this->queue()->shouldReturn(true);
+        $this->queue('mandrill')->shouldReturn(true);
     }
 }

--- a/spec/SendGrid/MailerSpec.php
+++ b/spec/SendGrid/MailerSpec.php
@@ -58,8 +58,8 @@ class MailerSpec extends ObjectBehavior
         $email->setFromName('Master Jedi Yoda');
         $email->addSmtpapiTo('janedoe@example.com', 'Jane Doe');
         $email->addSmtpapiTo('johndoe@example.com', 'John Doe');
-        $email->addCc('brucewayne@gotham.com', 'Bruce Wayne');
-        $email->addBcc('clarkkent@dailyplanet.com', 'Clark Kent');
+        $email->addSmtpapiTo('brucewayne@gotham.com', 'Bruce Wayne');
+        $email->addSmtpapiTo('clarkkent@dailyplanet.com', 'Clark Kent');
         $email->setSubject('Example subject');
         $email->setHtml(' ');
         $email->setTemplateId('example-template');
@@ -118,8 +118,12 @@ class MailerSpec extends ObjectBehavior
         $email->setHtml(' ');
         $email->setTemplateId('example-template');
         $email->setSections([
-            'Some variable' => 'Some variable value',
-            'Some different variable' => 'Some different variable value'
+            'Some variable_SECTION' => 'Some variable value',
+            'Some different variable_SECTION' => 'Some different variable value'
+        ]);
+        $email->setSubstitutions([
+            'Some variable' => ['Some variable_SECTION'],
+            'Some different variable' => ['Some different variable_SECTION']
         ]);
 
         $sendGrid->send($email)->shouldBeCalled();
@@ -227,11 +231,13 @@ class MailerSpec extends ObjectBehavior
         $email->setHtml(' ');
         $email->setTemplateId('example template');
         $email->setSections([
-            'global_one' => 'Example',
-            'global_two' => 'Another example'
+            'global_one_SECTION' => 'Example',
+            'global_two_SECTION' => 'Another example'
         ]);
         $email->setSubstitutions([
             'local' => ['Yet another example'],
+            'global_one' => ['global_one_SECTION'],
+            'global_two' => ['global_two_SECTION']
         ]);
 
         $sendGrid->send($email)->shouldBeCalled();
@@ -276,6 +282,6 @@ class MailerSpec extends ObjectBehavior
         $job = new Job($data);
         $queue->pushOn('sendgrid', $job)->shouldBeCalled();
 
-        $this->queue()->shouldReturn(true);
+        $this->queue('sendgrid')->shouldReturn(true);
     }
 }

--- a/src/Mandrill/Mailer.php
+++ b/src/Mandrill/Mailer.php
@@ -200,7 +200,7 @@ class Mailer implements MailerInterface
      * @param string|null $template
      * @return bool
      */
-    public function queue($queue = 'mandrill', $subject = null, $template = null)
+    public function queue($queue, $subject = null, $template = null)
     {
         if (null !== $subject) {
             $this->setSubject($subject);


### PR DESCRIPTION
Sendgrid API does not support mixing Smtpapi methods with non-Smtpapi
methods, therefore sending email to multiple recipients with additional
cc and/or bcc emails was not working. Now, all recipients are treated as
of 'to' type.

Sendgrid sections (in our understanding - global variables) can be used
only with substitutions. In order to allow defining global variables,
'fake' substitutions are created for every recipient that point to
specified section value.
